### PR TITLE
Provide SSL support for the website

### DIFF
--- a/.github/workflows/Destroy-k3s.yml
+++ b/.github/workflows/Destroy-k3s.yml
@@ -17,5 +17,12 @@ jobs:
         run: terraform init -backend-config="bucket=${{ secrets.TERRAFORM_BUCKET }}"
         working-directory: ./.terraform        
       - name: Terraform Destroy
-        run: terraform destroy -var public_key="${{ secrets.SSH_PUBLIC_KEY }}" -auto-approve
+        run: |
+          terraform destroy \
+          -var public_key="${{ secrets.SSH_PUBLIC_KEY }}" \
+          -var cloudflare_zone="${{ secrets.CLOUDFLARE_ZONE }}" \
+          -var cloudflare_api_token="${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+          -var subdomain="${{ secrets.SUBDOMAIN }}" \
+          -var is_https=${{ secrets.IS_HTTPS }} \
+          -auto-approve
         working-directory: ./.terraform

--- a/.github/workflows/app-deployment.yml
+++ b/.github/workflows/app-deployment.yml
@@ -12,19 +12,25 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v3
-        id: install
+      - name: Install Helm
+        uses: azure/setup-helm@v3
       - name: Save decoded kube config
         run: |
           echo "${{ secrets.BASE64_KUBE_CONFIG }}" > ./.base64.kube.config
           mkdir $HOME/.kube
           base64 -d ./.base64.kube.config > $HOME/.kube/config
-      - name: Create config map
-        # Ignore TLS because of self-signed certificate
+      - name: Helm Build Dependencies
+        run: helm dependency build
+        working-directory: ./.helm
+      - name: Helm Deploy
+        # Skip TLS verification because we are using a self-signed certificate
+        # Install Cert manager only if we are using HTTPS
         run: |
-          kubectl create configmap hello-world --from-file index.html -o yaml --dry-run=client --insecure-skip-tls-verify > configMap.yml
-          kubectl apply -f configMap.yml --insecure-skip-tls-verify
-      - name: Create app
-        # Ignore TLS because of self-signed certificate
-        run: kubectl apply -f ./.kubernetes/hello-world.yml --insecure-skip-tls-verify
+          helm install --insecure-skip-tls-verify hello-world --wait \
+          --set-file "index_file=index.html" \
+          --set is_https=${{ secrets.IS_HTTPS }} \
+          --set cert-manager.enabled=${{ secrets.IS_HTTPS }} \
+          --set email="${{ secrets.EMAIL }}" \
+          --set domain="${{ secrets.DOMAIN }}" \
+          --set is_prod=${{ secrets.IS_PROD }} \
+          ./.helm/

--- a/.github/workflows/k3s-provision.yml
+++ b/.github/workflows/k3s-provision.yml
@@ -15,9 +15,16 @@ jobs:
         uses: hashicorp/setup-terraform@v2
       - name: Initialize Terraform
         run: terraform init -backend-config="bucket=${{ secrets.TERRAFORM_BUCKET }}"
-        working-directory: ./.terraform        
+        working-directory: ./.terraform
       - name: Terraform Apply
-        run: terraform apply -var public_key="${{ secrets.SSH_PUBLIC_KEY }}" -auto-approve
+        run: |
+          terraform apply \
+          -var public_key="${{ secrets.SSH_PUBLIC_KEY }}" \
+          -var cloudflare_zone="${{ secrets.CLOUDFLARE_ZONE }}" \
+          -var cloudflare_api_token="${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+          -var subdomain="${{ secrets.SUBDOMAIN }}" \
+          -var is_https=${{ secrets.IS_HTTPS }} \
+          -auto-approve
         working-directory: ./.terraform
       - name: Set VM hostname as output
         run: echo hostname="$( terraform-bin output hostname )" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 
 # Base64 kube config
 .base64_kube.config
+
+# Helm
+*.tgz
+Chart.lock

--- a/.helm/.helmignore
+++ b/.helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/.helm/Chart.yaml
+++ b/.helm/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: hello-world
+description: A Helm chart for Hello World Iac
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+
+dependencies:
+  - name: cert-manager
+    version: 1.11.0
+    repository: https://charts.jetstack.io
+    condition: cert-manager.enabled    

--- a/.helm/templates/cert-manager.yml
+++ b/.helm/templates/cert-manager.yml
@@ -1,0 +1,30 @@
+{{ if .Values.is_https }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: le-http
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  acme:
+    email: {{ .Values.email }}
+    {{- $le_url := .Values.le_staging_url -}}
+    {{ if .Values.is_prod }}
+    {{- $le_url = .Values.le_prod_url -}}
+    {{ end}}
+    server: {{ $le_url }}
+    privateKeySecretRef:
+      # if not existing, it will register a new account and stores it
+      name: {{ tpl .Values.account_key . }}
+    solvers:
+      - http01:
+          # The ingressClass used to create the necessary ingress routes
+          ingress:
+            class: traefik
+{{ end }}

--- a/.helm/templates/hello-world.yml
+++ b/.helm/templates/hello-world.yml
@@ -1,0 +1,89 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name }}
+  annotations:
+    kubernetes.io/ingress.class: "traefik"
+  {{ if .Values.is_https }}    
+    cert-manager.io/issuer: "le-http"
+    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+  {{ end }}
+spec:
+{{ if .Values.is_https }}  
+  tls:
+    - hosts:
+        - {{ .Values.domain }}
+      secretName: {{ tpl .Values.secret_name . }}
+{{ end }}
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Chart.Name }}
+            port:
+              number: 80
+  {{ if .Values.is_https }}  
+    host: {{ .Values.domain }}
+  {{ end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+  selector:
+    app:  {{ .Chart.Name }}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}-nginx
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: {{ .Chart.Name }}-volume
+          mountPath: /usr/share/nginx/html
+      volumes:
+      - name: {{ .Chart.Name }}-volume
+        configMap:
+          name: {{ .Chart.Name }}
+---
+apiVersion: v1
+data:
+  index.html:
+{{ .Values.index_file | indent 4}}
+kind: ConfigMap
+metadata:
+  name: hello-world
+---
+{{ if .Values.is_https }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-https
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+{{ end }}

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -1,0 +1,15 @@
+# Default values for hello-world-iac.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+le_staging_url: "https://acme-staging-v02.api.letsencrypt.org/directory"
+le_prod_url: "https://acme-v02.api.letsencrypt.org/directory"
+account_key: '{{ .Values.domain | replace "." "-" }}-account-key'
+secret_name: '{{ .Values.domain | replace "." "-" }}-ingress-http-secret'
+
+cert-manager:
+  namespace: "cert-manager"
+  installCRDs: true
+  
+

--- a/.terraform/dns.tf
+++ b/.terraform/dns.tf
@@ -1,0 +1,8 @@
+# Add a record to the domain
+resource "cloudflare_record" "cloudflare_dns" {
+  count   = var.is_https ? 1 : 0
+  zone_id = var.cloudflare_zone
+  name    = var.subdomain
+  value   = aws_instance.k3s.public_ip
+  type    = "A"
+}

--- a/.terraform/ec2.tf
+++ b/.terraform/ec2.tf
@@ -5,7 +5,7 @@ resource "aws_key_pair" "ec2_key" {
 
 resource "aws_instance" "k3s" {
   ami                         = data.aws_ami.ubuntu.id
-  instance_type               = "t2.micro"
+  instance_type               = var.is_https ? "t2.small" : "t2.micro"
   key_name                    = aws_key_pair.ec2_key.key_name
   subnet_id                   = aws_subnet.k3s_subnet.id
   vpc_security_group_ids      = [aws_security_group.security_group.id]

--- a/.terraform/provider.tf
+++ b/.terraform/provider.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4.0.4"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
   }
 
   backend "s3" {
@@ -20,4 +24,8 @@ terraform {
 
 provider "aws" {
   region = "us-east-1"
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
 }

--- a/.terraform/variables.tf
+++ b/.terraform/variables.tf
@@ -1,3 +1,19 @@
 variable "public_key" {
   type = string
 }
+
+variable "cloudflare_api_token" {
+  type = string
+}
+
+variable "cloudflare_zone" {
+  type = string
+}
+
+variable "subdomain" {
+  type = string
+}
+
+variable "is_https" {
+  type = bool
+}


### PR DESCRIPTION
Changes:

1. Replace kubectl by helm to
    1.1. Easier install cert-manager for cert management
    1.2. Use different Let's encrypt URL for registering cert  
2. Update Github workflow accordingly because of using helm
3. Update Terraform IaC code to 
    3.1. Add public DNS entry which is necessarily to obtain Let's encrypt cert
    3.2. Use more powerful machine when SSL support is specified, which is necessarily, because cert-manager and other apps consume much more resources than the one with no SSL support
4. Update Github workflow accordingly because of Terraform Iac code change